### PR TITLE
Add .public_key_info accessor to PrivateKeyInfo.

### DIFF
--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -404,6 +404,15 @@ class KeysTests(unittest.TestCase):
         self.assertEqual(public_key['public_key'].native, private_key.public_key.native)
 
     @data('key_pairs', True)
+    def public_key_info_property(self, private_key_file, public_key_file, *_):
+        with open(os.path.join(fixtures_dir, private_key_file), 'rb') as f:
+            private_key = keys.PrivateKeyInfo.load(f.read())
+        with open(os.path.join(fixtures_dir, public_key_file), 'rb') as f:
+            public_key = keys.PublicKeyInfo.load(f.read())
+
+        self.assertEqual(public_key.dump(), private_key.public_key_info.dump())
+
+    @data('key_pairs', True)
     def algorithm_name(self, private_key_file, public_key_file, algorithm, _):
         with open(os.path.join(fixtures_dir, private_key_file), 'rb') as f:
             private_key = keys.PrivateKeyInfo.load(f.read())


### PR DESCRIPTION
Here's a pass at PrivateKeyInfo.public_key_info. Two interesting things to note:

1. PublicKeyInfo overrides the public_key field spec for ec keys, so we can't assign a ParsableOctetBitString to the public_key field in wrap(). I narrowed the definition to require a public_key that matches the value spec. This method was not previously covered by unit tests, so it's hard to know if the original definition was actually working.

2. The unit test has to compare .dump() rather than .native (which doesn't match for some algorithms). I'm not sure if native representations are guaranteed to be canonical, so maybe it's just an idiosyncrasy in generating native representations after mutating a container.

Thanks,
Peter