### PR TITLE
Fix ECPoint to_coords

### DIFF
--- a/asn1crypto/keys.py
+++ b/asn1crypto/keys.py
@@ -177,7 +177,7 @@ class _ECPoint():
             A 2-element tuple containing integers (X, Y)
         """
 
-        data = self.native
+        data = self.contents
         first_byte = data[0:1]
 
         # Uncompressed


### PR DESCRIPTION
When using the 'to_coords' method of _ECPoint, we must use the 'contents' attribute instead of the 'native' one. Indeed, 'native' loses the first byte which is needed to parse the coordinates.