### PR TITLE
Make `setup.py clean` compatible with distutils'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from asn1crypto import version
 
 class CleanCommand(Command):
     user_options = [
-        ('all', None, '(Compatibility with original clean command)')
+        ('all', 'a', '(Compatibility with original clean command)')
     ]
 
     def initialize_options(self):


### PR DESCRIPTION
This notably fixes building with stdeb which uses the short argument
for `setup.py clean`.

See https://github.com/python-git/python/blob/715a6e5035bb21ac49382772076ec4c630d6e960/Lib/distutils/command/clean.py#L28