### PR TITLE
Add reference to secp256k1

### DIFF
--- a/asn1crypto/keys.py
+++ b/asn1crypto/keys.py
@@ -364,6 +364,7 @@ class NamedCurve(ObjectIdentifier):
         '1.2.840.10045.3.1.6': 'prime239v3',
         # https://tools.ietf.org/html/rfc5480#page-5
         '1.3.132.0.1': 'sect163k1',
+        '1.3.132.0.10': 'secp256k1',
         '1.3.132.0.15': 'sect163r2',
         '1.2.840.10045.3.1.1': 'secp192r1',
         '1.3.132.0.33': 'secp224r1',

--- a/asn1crypto/keys.py
+++ b/asn1crypto/keys.py
@@ -363,6 +363,7 @@ class NamedCurve(ObjectIdentifier):
         '1.2.840.10045.3.1.5': 'prime239v2',
         '1.2.840.10045.3.1.6': 'prime239v3',
         # https://tools.ietf.org/html/rfc5480#page-5
+        # http://www.secg.org/sec2-v2.pdf
         '1.3.132.0.1': 'sect163k1',
         '1.3.132.0.10': 'secp256k1',
         '1.3.132.0.15': 'sect163r2',


### PR DESCRIPTION
For #129 . Found named curve at https://www.flexiprovider.de/CurvesGfpSEC2.html#secp256k1.

I could also add the base point for key derivation if it is of interest but I'm not really using it.