### PR TITLE
support windows pe file nested sha256 signature

### DIFF
--- a/asn1crypto/cms.py
+++ b/asn1crypto/cms.py
@@ -103,6 +103,8 @@ class CMSAttributeType(ObjectIdentifier):
         '1.2.840.113549.1.9.16.2.14': 'signature_time_stamp_token',
         # https://tools.ietf.org/html/rfc6211#page-5
         '1.2.840.113549.1.9.52': 'cms_algorithm_protection',
+        "1.3.6.1.4.1.311.2.4.1": "ms_spc_nested_signature",
+        "1.3.6.1.4.1.311.3.3.1": "ms_timestamping_signature",
     }
 
 
@@ -929,4 +931,6 @@ CMSAttribute._oid_specs = {
     'counter_signature': SignerInfos,
     'signature_time_stamp_token': SetOfContentInfo,
     'cms_algorithm_protection': SetOfCMSAlgorithmProtection,
+    'ms_spc_nested_signature': SetOfContentInfo,
+    'ms_timestamping_signature': SetOfContentInfo,
 }


### PR DESCRIPTION
now windows pe file are signed with both sha1 and sha256.