### PR TITLE
Corner cases in int_to_bytes

### DIFF
--- a/asn1crypto/util.py
+++ b/asn1crypto/util.py
@@ -49,12 +49,15 @@ if sys.version_info <= (3,):
             If the byte string should be encoded using two's complement
 
         :param width:
-            None == auto, otherwise an integer of the byte width for the return
-            value
+            If None, the minimal possible size (but at least 1),
+            otherwise an integer of the byte width for the return value
 
         :return:
             A byte string
         """
+
+        if value == 0 and width == 0:
+            return b''
 
         # Handle negatives in two's complement
         is_neg = False
@@ -73,6 +76,8 @@ if sys.version_info <= (3,):
             output = b'\x00' + output
 
         if width is not None:
+            if len(output) > width:
+                raise OverflowError('int too big to convert')
             if is_neg:
                 pad_char = b'\xFF'
             else:
@@ -146,8 +151,8 @@ else:
             If the byte string should be encoded using two's complement
 
         :param width:
-            None == auto, otherwise an integer of the byte width for the return
-            value
+            If None, the minimal possible size (but at least 1),
+            otherwise an integer of the byte width for the return value
 
         :return:
             A byte string


### PR DESCRIPTION
Corner cases in int_to_bytes

`int_to_bytes(0, width=0)` returns `b''` in py3 but `b'\x00'` in py2.
py2 implementation will now return `b''` too.

`int_to_bytes(12345, width=1)` raises `OverflowError` in py3 but not in py2.
py2 will now also raise the Exception.

Also completed test coverage for `int_to_bytes` and `int_from_bytes`.