### PR TITLE
Fix encoding of large tags (>=31)

### DIFF
--- a/asn1crypto/parser.py
+++ b/asn1crypto/parser.py
@@ -270,11 +270,10 @@ def _dump_header(class_, method, tag, contents):
     id_num |= method << 5
 
     if tag >= 31:
-        header += chr_cls(id_num | 31)
-        while tag > 0:
-            continuation_bit = 0x80 if tag > 0x7F else 0
-            header += chr_cls(continuation_bit | (tag & 0x7F))
-            tag = tag >> 7
+        while tag >= 0x80:
+            header = chr_cls(0x80 | (tag & 0x7f)) + header
+            tag >>= 7
+        header = chr_cls(id_num | 31) + header + chr_cls(tag)
     else:
         header += chr_cls(id_num | tag)
 


### PR DESCRIPTION
Encoding of ASN.1 tags larger than 30 was broken. These kind of tags are commonly used on smartcards.