### PR TITLE
Add __getinitargs__ method to util.timezone

### DIFF
--- a/asn1crypto/util.py
+++ b/asn1crypto/util.py
@@ -161,6 +161,16 @@ if sys.version_info <= (3,):
                 return False
             return self._offset == other._offset
 
+        def __getinitargs__(self):
+            """
+            Called by tzinfo.__reduce__ to support pickle and copy.
+
+            :return:
+                offset and name, to be used for __init__
+            """
+
+            return self._offset, self._name
+
         def tzname(self, dt):
             """
             :param dt:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -409,6 +409,15 @@ class CoreTests(unittest.TestCase):
             # Is past 2050
             core.UTCTime(datetime(2106, 2, 7, 6, 28, 16, tzinfo=util.timezone.utc))
 
+    def test_utctime_copy(self):
+        a = core.UTCTime(datetime(2019, 11, 11, 17, 45, 18, tzinfo=util.timezone.utc))
+        # Ensure _native is set because we want to test copy on the nested timezone object.
+        a.native
+        b = a.copy()
+        self.assertEqual(a.native, b.native)
+        self.assertEqual(a.contents, b.contents)
+        self.assertEqual(a.dump(), b.dump())
+
     @staticmethod
     def generalized_time_info():
         def tz(hours, minutes=0):


### PR DESCRIPTION
If a timezone object is copied, its __reduce__ method is called which in
turn calls __getinitargs__ to get arguments for __init__ on the new
object.
If that function is missing, __init_ is called with too few parameters.

Problem can be triggered by calling copy or untag on UTCTime or GeneralizedTime
or any other object where the native value includes a datetime

Fixes #167