### PR TITLE
Added arm64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ matrix:
       language: python
       python: "3.7"
     - os: linux
+      arch: arm64
+      dist: bionic
+      language: python
+      python: "3.7"
+    - os: linux
       dist: xenial
       language: python
       python: "pypy"


### PR DESCRIPTION
Travis-CI has added support for ARM64. Added ARM64 jobs in Travis-CI for Python 3.7.