### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Include missing files in sdist for #183

Tested with

```
+++ mktemp -d
++ D=/tmp/tmp.wP9S0XfMTv
++ trap 'rm -rf /tmp/tmp.wP9S0XfMTv' EXIT
++ python -m venv /tmp/tmp.wP9S0XfMTv
++ python setup.py sdist -d /tmp/tmp.wP9S0XfMTv
running sdist
running egg_info
writing asn1crypto.egg-info/PKG-INFO
writing dependency_links to asn1crypto.egg-info/dependency_links.txt
writing top-level names to asn1crypto.egg-info/top_level.txt
reading manifest file 'asn1crypto.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'asn1crypto.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
creating asn1crypto-1.3.0
creating asn1crypto-1.3.0/asn1crypto
creating asn1crypto-1.3.0/asn1crypto.egg-info
copying files to asn1crypto-1.3.0...
copying LICENSE -> asn1crypto-1.3.0
copying MANIFEST.in -> asn1crypto-1.3.0
copying changelog.md -> asn1crypto-1.3.0
copying readme.md -> asn1crypto-1.3.0
copying setup.py -> asn1crypto-1.3.0
copying asn1crypto/__init__.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/_errors.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/_inet.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/_int.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/_iri.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/_ordereddict.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/_teletex_codec.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/_types.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/algos.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/cms.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/core.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/crl.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/csr.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/keys.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/ocsp.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/parser.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/pdf.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/pem.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/pkcs12.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/tsp.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/util.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/version.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto/x509.py -> asn1crypto-1.3.0/asn1crypto
copying asn1crypto.egg-info/LICENSE -> asn1crypto-1.3.0/asn1crypto.egg-info
copying asn1crypto.egg-info/PKG-INFO -> asn1crypto-1.3.0/asn1crypto.egg-info
copying asn1crypto.egg-info/SOURCES.txt -> asn1crypto-1.3.0/asn1crypto.egg-info
copying asn1crypto.egg-info/dependency_links.txt -> asn1crypto-1.3.0/asn1crypto.egg-info
copying asn1crypto.egg-info/top_level.txt -> asn1crypto-1.3.0/asn1crypto.egg-info
Writing asn1crypto-1.3.0/setup.cfg
Creating tar archive
removing 'asn1crypto-1.3.0' (and everything under it)
++ cd /
++ /tmp/tmp.wP9S0XfMTv/bin/pip install /tmp/tmp.wP9S0XfMTv/asn1crypto-1.3.0.tar.gz
Processing /tmp/tmp.wP9S0XfMTv/asn1crypto-1.3.0.tar.gz
Installing collected packages: asn1crypto
  Running setup.py install for asn1crypto: started
    Running setup.py install for asn1crypto: finished with status 'done'
Successfully installed asn1crypto-1.3.0
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
++ echo Success
Success
+++ rm -rf /tmp/tmp.wP9S0XfMTv
```
