### PR TITLE
fix example for Name dict

### DIFF
--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -987,7 +987,7 @@ class Name(Choice):
 
         :param name_dict:
             A dict of name information, e.g. {"common_name": "Will Bond",
-            "country_name": "US", "organization": "Codex Non Sufficit LC"}
+            "country_name": "US", "organization_name": "Codex Non Sufficit LC"}
 
         :param use_printable:
             A bool - if PrintableString should be used for encoding instead of


### PR DESCRIPTION
`organization` key does not exists in `NameType`, so actually using it results in it trying to be parsed as an int