### PR TITLE
Fix various issues in the parser

### DIFF
--- a/asn1crypto/parser.py
+++ b/asn1crypto/parser.py
@@ -226,10 +226,9 @@ def _parse(encoded_data, data_len, pointer=0, lengths_only=False, depth=0):
             # just scanned looking for \x00\x00, nested indefinite length values
             # would not work.
             contents_end = pointer
-            while contents_end < data_len:
-                sub_header_end, contents_end = _parse(encoded_data, data_len, contents_end, lengths_only=True, depth=depth+1)
-                if contents_end == sub_header_end and encoded_data[contents_end - 2:contents_end] == b'\x00\x00':
-                    break
+            while data_len < contents_end + 2 or encoded_data[contents_end:contents_end+2] != b'\x00\x00':
+                _, contents_end = _parse(encoded_data, data_len, contents_end, lengths_only=True, depth=depth+1)
+            contents_end += 2
             trailer = b'\x00\x00'
 
     if contents_end > data_len:

--- a/asn1crypto/parser.py
+++ b/asn1crypto/parser.py
@@ -201,10 +201,14 @@ def _parse(encoded_data, data_len, pointer=0, lengths_only=False, depth=0):
         while True:
             num = _get_byte(encoded_data, data_len, pointer)
             pointer += 1
+            if num == 0x80 and tag == 0:
+                raise ValueError('Non-minimal tag encoding')
             tag *= 128
             tag += num & 127
             if num >> 7 == 0:
                 break
+        if tag < 31:
+            raise ValueError('Non-minimal tag encoding')
 
     length_octet = _get_byte(encoded_data, data_len, pointer)
     pointer += 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -142,3 +142,12 @@ class ParserTests(unittest.TestCase):
     def test_parser_indef_primitive(self):
         with self.assertRaises(ValueError):
             parser.parse(b'\x04\x80\x00\x00')
+
+    def test_parse_nonminimal_tag(self):
+        with self.assertRaises(ValueError):
+            # Should be b'\x04\x00'
+            parser.parse(b'\x1f\x04\x00')
+
+        with self.assertRaises(ValueError):
+            # Should be b'\xbf\x1f\x00'
+            parser.parse(b'\xbf\x80\x1f\x00')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -121,3 +121,20 @@ class ParserTests(unittest.TestCase):
     def test_parser_bounded_recursion(self):
         with self.assertRaises(ValueError):
             parser.parse(b'\x30\x80' * 1000)
+
+    def test_parser_indef_missing_eoc(self):
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x30\x80')
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x30\x80\x30\x80\x00\x00')
+
+    def test_parser_indef_long_zero_length(self):
+        # The parser should not confuse the long-form zero length for an EOC.
+        result = parser.parse(b'\x30\x80\x30\x82\x00\x00\x00\x00')
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(0, result[0])
+        self.assertEqual(1, result[1])
+        self.assertEqual(16, result[2])
+        self.assertEqual(b'\x30\x80', result[3])
+        self.assertEqual(b'\x30\x82\x00\x00', result[4])
+        self.assertEqual(b'\x00\x00', result[5])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -138,3 +138,7 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(b'\x30\x80', result[3])
         self.assertEqual(b'\x30\x82\x00\x00', result[4])
         self.assertEqual(b'\x00\x00', result[5])
+
+    def test_parser_indef_primitive(self):
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x04\x80\x00\x00')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -117,3 +117,7 @@ class ParserTests(unittest.TestCase):
             parser.parse(b'\x04\x02\x00')
         with self.assertRaises(ValueError):
             parser.parse(b'\x04\x81\x80' + (b'\x00' * 127))
+
+    def test_parser_bounded_recursion(self):
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x30\x80' * 1000)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -88,3 +88,32 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(b'\x7f\x81\x80\x00\x00', result[3])
         self.assertEqual(b'', result[4])
         self.assertEqual(b'', result[5])
+
+    def test_parser_insufficient_data(self):
+        # No tag
+        with self.assertRaises(ValueError):
+            parser.parse(b'')
+
+        # Long-form tag is truncated
+        with self.assertRaises(ValueError):
+            parser.parse(b'\xbf')
+        with self.assertRaises(ValueError):
+            parser.parse(b'\xbf\x81')
+
+        # No length
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x04')
+        with self.assertRaises(ValueError):
+            parser.parse(b'\xbf\x1f')
+
+        # Long-form length is truncated
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x04\x81')
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x04\x82\x01')
+
+        # Contents are truncated
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x04\x02\x00')
+        with self.assertRaises(ValueError):
+            parser.parse(b'\x04\x81\x80' + (b'\x00' * 127))


### PR DESCRIPTION
This PR contains a handful of commits that are probably best reviewed individually. They are:

* Fix missing bounds checks in parser
* Bound the recursion depth when walking indefinite-length encoding
* Fix indefinite-length parsing 
* Forbid indefinite-length primitive elements
* Tags must be minimally encoded