### PR TITLE
Fix tagging for RoleSyntax and SecurityCategory

### DIFF
--- a/asn1crypto/cms.py
+++ b/asn1crypto/cms.py
@@ -315,7 +315,7 @@ class SetOfSvceAuthInfo(SetOf):
 class RoleSyntax(Sequence):
     _fields = [
         ('role_authority', GeneralNames, {'implicit': 0, 'optional': True}),
-        ('role_name', GeneralName, {'implicit': 1}),
+        ('role_name', GeneralName, {'explicit': 1}),
     ]
 
 
@@ -337,7 +337,7 @@ class ClassList(BitString):
 class SecurityCategory(Sequence):
     _fields = [
         ('type', ObjectIdentifier, {'implicit': 0}),
-        ('value', Any, {'implicit': 1}),
+        ('value', Any, {'explicit': 1}),
     ]
 
 

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -901,3 +901,13 @@ class CMSTests(unittest.TestCase):
             ]),
             content['certificates'][0].chosen['tbs_certificate']['subject'].native
         )
+
+    def test_create_role_syntax(self):
+        rs = cms.RoleSyntax({'role_name': {'rfc822_name': 'test@example.com'}})
+        self.assertEqual(
+            util.OrderedDict([
+                ('role_authority', None),
+                ('role_name', 'test@example.com')
+            ]),
+            rs.native
+        )


### PR DESCRIPTION
This PR rectifies two incorrect applications of the 'implicit tags' tagging default declared in the X.509 ASN.1 module (EDIT: the relevant definitions are also reproduced in RFC 5755).

Concretely, it updates the `asn1crypto` definitions of `RoleSyntax` and `SecurityCategory`. As stipulated in ITU-T Rec. X.680 § C.3.2.2 (g), the 'implicit tags' directive does not apply to choice types and open types, since that would make them impossible to decode reliably.
In fact, `asn1crypto` currently raises an exception when trying to encode a `RoleSyntax` value, for this exact reason.

All this PR does is change `implicit` to `explicit` in those two locations, and add a regression test.