### PR TITLE
Fix Clearance type definition

### DIFF
--- a/asn1crypto/cms.py
+++ b/asn1crypto/cms.py
@@ -347,9 +347,9 @@ class SetOfSecurityCategory(SetOf):
 
 class Clearance(Sequence):
     _fields = [
-        ('policy_id', ObjectIdentifier, {'implicit': 0}),
-        ('class_list', ClassList, {'implicit': 1, 'default': 'unclassified'}),
-        ('security_categories', SetOfSecurityCategory, {'implicit': 2, 'optional': True}),
+        ('policy_id', ObjectIdentifier),
+        ('class_list', ClassList, {'default': set(['unclassified'])}),
+        ('security_categories', SetOfSecurityCategory, {'optional': True}),
     ]
 
 

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -21,6 +21,30 @@ tests_root = os.path.dirname(__file__)
 fixtures_dir = os.path.join(tests_root, 'fixtures')
 
 
+class ClearanceTests(unittest.TestCase):
+
+    def test_clearance_decode_bad_tagging(self):
+        rfc_3281_wrong_tagging = b'\x30\x08\x80\x02\x88\x37\x81\x02\x02\x4c'
+        # This test documents the fact that we can't deal with the "wrong"
+        # version of Clearance in RFC 3281
+        self.assertRaises(
+            ValueError,
+            lambda: cms.Clearance.load(rfc_3281_wrong_tagging).native
+        )
+
+    def test_clearance_decode_correct_tagging(self):
+        correct_tagging = b'\x30\x08\x06\x02\x88\x37\x03\x02\x02\x4c'
+        clearance_obj = cms.Clearance.load(correct_tagging)
+        self.assertEqual(
+            util.OrderedDict([
+                ('policy_id', '2.999'),
+                ('class_list', set(['secret', 'top_secret', 'unclassified'])),
+                ('security_categories', None)
+            ]),
+            clearance_obj.native
+        )
+
+
 class CMSTests(unittest.TestCase):
 
     def test_create_content_info_data(self):


### PR DESCRIPTION
Hi there,

Here's another pull request to fix a tagging issue in some type definitions relating to attribute certificates (compare #218).

- According to RFC 5755 (which obsoletes RFC 3281) the tagging on
  Clearance in RFC 3281 was wrong, and inconsistent with the definition in
  the ITU Rec. X.50x series. This commit fixes the tagging to be
  consistent with RFC 5755.

- The 'default' value of classList is `'unclassified'`, while it should be
  `{'unclassified'}`. This caused asn1crypto to throw an error whenever
  the caller would try to encode a Clearance value.

------

References for the erroneous tagging in RFC 3281 and the history of that change:

 - https://datatracker.ietf.org/doc/html/rfc5755#section-4.4.6
 - https://www.rfc-editor.org/errata_search.php?rfc=3281&rec_status=0 (see in particular Erratum 302)