### PR TITLE
hash_algo for Ed25519 and Ed448 should not expose internals

### DIFF
--- a/asn1crypto/algos.py
+++ b/asn1crypto/algos.py
@@ -378,8 +378,8 @@ class SignedDigestAlgorithm(_ForceNullParameters, Sequence):
             'sha256_ecdsa': 'sha256',
             'sha384_ecdsa': 'sha384',
             'sha512_ecdsa': 'sha512',
-            'ed25519': 'sha512',
-            'ed448': 'shake256',
+            'ed25519': 'raw',
+            'ed448': 'raw',
         }
         if algorithm in algo_map:
             return algo_map[algorithm]

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -549,6 +549,11 @@ class X509Tests(unittest.TestCase):
                 'rsassa_pss',
                 'sha256'
             ),
+            (
+                'keys/test-ed448.crt',
+                'ed448',
+                'raw'
+            )
         )
 
     @data('signature_algo_info')
@@ -3545,6 +3550,10 @@ class X509Tests(unittest.TestCase):
         self.assertEqual(
             'ed448',
             subject_public_key_algorithm['algorithm'].native
+        )
+        self.assertEqual(
+            'raw',
+            cert.hash_algo
         )
         self.assertEqual(
             b'\xdc\'\x19\xbb\xff\xec\xef\xae\xc4\'\x91\xa1\xe7}\xbaN\xe1\xbe'


### PR DESCRIPTION
Unlike RSA which requires hashing prior to signing, pure
Ed25519 and Ed448 signing algorithm identifiers do not refer
to the "hashing algorithm" at all.

certvalidator uses this to detect [weak hashing algorithms](https://github.com/wbond/certvalidator/blob/0.11.1/certvalidator/validate.py#L306),
but passing hashing algorithm separately to EdDSA signing/verification
functions makes no sense.

[pyca/cryptography](https://cryptography.io/en/37.0.2/x509/reference/#cryptography.x509.Certificate.signature_hash_algorithm) prefers to say None here.

Let's call it "raw" then.