### PR TITLE
Fix ArchiveTimestampSequence definition

### DIFF
--- a/asn1crypto/tsp.py
+++ b/asn1crypto/tsp.py
@@ -208,8 +208,12 @@ class ArchiveTimeStamp(Sequence):
     ]
 
 
-class ArchiveTimeStampSequence(SequenceOf):
+class ArchiveTimeStampChain(SequenceOf):
     _child_spec = ArchiveTimeStamp
+
+
+class ArchiveTimeStampSequence(SequenceOf):
+    _child_spec = ArchiveTimeStampChain
 
 
 class EvidenceRecord(Sequence):


### PR DESCRIPTION
RFC4998, Section 5.1 defines the ArchiveTimestampSequence as:

```
ArchiveTimeStampChain    ::= SEQUENCE OF ArchiveTimeStamp
ArchiveTimeStampSequence ::= SEQUENCE OF ArchiveTimeStampChain
```

`asn1crypto.tsp` defines `ArchiveTimeStampSequence` as:
```
class ArchiveTimeStampSequence(SequenceOf):
   _child_spec = ArchiveTimeStamp
```
and `ArchiveTimeStampChain` is absent.

This MR fixes the issue.