### PR TITLE
Allow better pickle integration

### DIFF
--- a/asn1crypto/core.py
+++ b/asn1crypto/core.py
@@ -166,6 +166,15 @@ def load(encoded_data, strict=False):
     return Asn1Value.load(encoded_data, strict=strict)
 
 
+def unpickle_helper(asn1crypto_cls, der_bytes):
+    """
+    Helper function to integrate with pickle.
+
+    Note that this must be an importable top-level function.
+    """
+    return asn1crypto_cls.load(der_bytes)
+
+
 class Asn1Value(object):
     """
     The basis of all ASN.1 values
@@ -480,6 +489,12 @@ class Asn1Value(object):
         """
 
         return self.__repr__()
+
+    def __reduce__(self):
+        """
+        Permits pickling Asn1Value objects using their DER representation.
+        """
+        return unpickle_helper, (self.__class__, self.dump())
 
     def _new_instance(self):
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import unicode_literals, division, absolute_import, print_function
 
+import pickle
 import unittest
 import os
 from datetime import datetime, timedelta
@@ -1375,3 +1376,11 @@ class CoreTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Second arc must be "):
             core.ObjectIdentifier("0.40")
+
+    def test_pickle_integration(self):
+        orig = Seq({'id': '2.3.4', 'value': b"\xde\xad\xbe\xef"})
+        pickled_bytes = pickle.dumps(orig)
+        # ensure that our custom pickling implementation was used
+        self.assertIn(b"unpickle_helper", pickled_bytes)
+        unpickled = pickle.loads(pickled_bytes)
+        self.assertEqual(orig.native, unpickled.native)


### PR DESCRIPTION
The way `asn1crypto` manages its classes does not always play nice with unpickling objects. In particular, pickled `Asn1Value`s cannot always be unpickled in a "fresh" interpreter where the class setup methods for `asn1crypto`'s classes haven't been called yet. See discussion in #239.

This commit implements `__reduce__` on Asn1Value in such a way that pickle will use `asn1crypto`'s own DER serialisation/deserialisation functionality to handle pickling and unpickling.

Fixes #239.

EDIT: Note that CI will fail until https://github.com/wbond/certvalidator/pull/42 is merged.