### PR TITLE
Update CRL versions to match RFC 5280.

### DIFF
--- a/asn1crypto/crl.py
+++ b/asn1crypto/crl.py
@@ -44,7 +44,6 @@ class Version(Integer):
     _map = {
         0: 'v1',
         1: 'v2',
-        2: 'v3',
     }
 
 


### PR DESCRIPTION
Update CRL versions to match RFC 5280.

See https://datatracker.ietf.org/doc/html/rfc5280#section-5.1.2.1"

Fixes #236.