### PR TITLE
support for attestation extension

### DIFF
--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -1815,6 +1815,7 @@ class EntrustVersionInfo(Sequence):
         ('entrust_info_flags', BitString)
     ]
 
+
 # Attestation definitions from https://source.android.com/docs/security/features/keystore/attestation
 class AttestationVersion(Integer):
     _map = {
@@ -1826,6 +1827,7 @@ class AttestationVersion(Integer):
         100: 'KeyMint version 1.0',
         200: 'KeyMint version 2.0',
     }
+
 
 class KeyMasterVersion(Integer):
     _map = {
@@ -1839,12 +1841,14 @@ class KeyMasterVersion(Integer):
         200: 'KeyMint version 2.0',
     }
 
+
 class AttestationSecurityLevel(Enumerated):
     _map = {
         0: 'Software',
         1: 'TrustedEnvironment',
         2: 'StrongBox',
     }
+
 
 class Origin(Integer):
     _map = {
@@ -1854,6 +1858,7 @@ class Origin(Integer):
         3: 'UNKNOWN',
         4: 'SECURELY_IMPORTED',
         }
+
 
 class Purpose(Integer):
     _map = {
@@ -1865,8 +1870,10 @@ class Purpose(Integer):
         5: 'WRAP_KEY',
         }
 
+
 class SetOfPurposes(SetOf):
     _child_spec = Purpose
+
 
 class Padding(Integer):
     _map = {
@@ -1878,14 +1885,18 @@ class Padding(Integer):
         64: 'PKCS7',
         }
 
+
 class SetOfPadding(SetOf):
     _child_spec = Padding
+
 
 class SetOfOctetStrings(SetOf):
     _child_spec = OctetString
 
+
 class SetOfInteger(SetOf):
     _child_spec = Integer
+
 
 class AlgorithmType(Integer):
     _map = {
@@ -1895,6 +1906,7 @@ class AlgorithmType(Integer):
         33: '3DES',
         128: 'HMAC',
     }
+
 
 class DigestType(Integer):
     _map = {
@@ -1907,8 +1919,10 @@ class DigestType(Integer):
         6: 'SHA_2_512',
     }
 
+
 class SetOfDigests(SetOf):
     _child_spec = DigestType
+
 
 class EllipticCurveType(Integer):
     _map = {
@@ -1918,6 +1932,7 @@ class EllipticCurveType(Integer):
         3: 'EC_CURVE_P_521',
     }
 
+
 class UserAuthenticationType(Integer):
     _map = {
         0: 'NONE',
@@ -1925,6 +1940,7 @@ class UserAuthenticationType(Integer):
         2: 'FINGERPRINT',
         3: 'ANY',
     }
+
 
 class VerifiedBootState(Enumerated):
     _map = {
@@ -1934,14 +1950,17 @@ class VerifiedBootState(Enumerated):
         3: 'Failed',
     }
 
+
 class PackageInfo(Sequence):
     _fields = [
         ('package_info', OctetString),
         ('version', Integer),
     ]
 
+
 class SetOfPackageInfos(SetOf):
     _child_spec = PackageInfo
+
 
 class AttestationApplicationId(Sequence):
     _fields = [
@@ -1949,8 +1968,8 @@ class AttestationApplicationId(Sequence):
         ('signature_digests', SetOfOctetStrings),
     ]
 
-class AttestationApplicationIdWrapper(ParsableOctetString):
 
+class AttestationApplicationIdWrapper(ParsableOctetString):
     def parse(self, spec=AttestationApplicationId, spec_params=None):
         if self._parsed is None or self._parsed[1:3] != (spec, spec_params):
             parsed_value, _ = _parse_build(self.__bytes__(), spec=spec, spec_params=spec_params)
@@ -1959,9 +1978,8 @@ class AttestationApplicationIdWrapper(ParsableOctetString):
 
     @property
     def native(self):
-        if self._native is None:
-            byte_string = self.__bytes__()
-        self.parse()
+        if not self.parsed.native:
+            self.parse()
         return self.parsed.native
 
 
@@ -1988,7 +2006,7 @@ class UnixTimestamp(Integer):
             ))
 
         self._native=value
-        self.contents=datetime.datetime.fromtimestamp(value/1000)
+        self.contents=datetime.datetime.fromtimestamp(value / 1000)
 
     @property
     def native(self):
@@ -2007,6 +2025,7 @@ class RootOfTrust(Sequence):
         ('verified_boot_state', VerifiedBootState),
         ('verified_boot_hash', OctetString),
     ]
+
 
 class AuthorizationList(Sequence):
     _fields = [
@@ -2053,6 +2072,7 @@ class AuthorizationList(Sequence):
         ('device_unique_attestation', Null, {'explicit': 720, 'optional': True}),
     ]
 
+
 class Attestation(Sequence):
     _fields = [
         ('attestation_version', AttestationVersion, {'default': 'Keymaster version 1.0'}),
@@ -2064,6 +2084,7 @@ class Attestation(Sequence):
         ('software_enforced', AuthorizationList),
         ('tee_enforced', AuthorizationList),
     ]
+
 
 class NetscapeCertificateType(BitString):
     _map = {

--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -372,7 +372,7 @@ class IPAddress(OctetString):
         self._native = original_value
         self.contents = inet_pton(family, value) + cidr_bytes
         self._bytes = self.contents
-        self._header = 'None'
+        self._header = None
         if self._trailer != b'':
             self._trailer = b''
 

--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -2010,12 +2010,12 @@ class AttestationApplicationIdWrapper(ParsableOctetString):
 class UnixTimestamp(Integer):
     def parse(self, spec=None, spec_params=None):
         """
-        This method is not applicable to IP addresses
+        This method is not applicable to UnixTimestamp
         """
 
         raise ValueError(unwrap(
             '''
-            IP address values can not be parsed
+            UnixTimestamp values can not be parsed
             '''
         ))
 
@@ -2023,7 +2023,7 @@ class UnixTimestamp(Integer):
         if not isinstance(value, int):
             raise TypeError(unwrap(
                 '''
-                %s value must be a unicode string, not %s
+                %s value must be a int value, not %s
                 ''',
                 type_name(self),
                 type_name(value)

--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -2005,8 +2005,8 @@ class UnixTimestamp(Integer):
                 type_name(value)
             ))
 
-        self._native=value
-        self.contents=datetime.datetime.fromtimestamp(value / 1000)
+        self._native = value
+        self.contents = datetime.datetime.fromtimestamp(value / 1000)
 
     @property
     def native(self):
@@ -2030,9 +2030,9 @@ class RootOfTrust(Sequence):
 class AuthorizationList(Sequence):
     _fields = [
         ('purpose',SetOfPurposes,{'explicit': 1, 'optional': True}),
-        ('algorithm', AlgorithmType, {'explicit': 2,'optional': True}),
+        ('algorithm', AlgorithmType, {'explicit': 2, 'optional': True}),
         ('key_size', Integer, {'explicit': 3, 'optional': True}),
-        ('digest', SetOfDigests, {'explicit': 5,'optional': True}),
+        ('digest', SetOfDigests, {'explicit': 5, 'optional': True}),
         ('padding', SetOfPadding, {'explicit': 6, 'optional': True}),
         ('ec_curve', EllipticCurveType, {'explicit': 10, 'optional': True}),
         ('rsa_public_exponent', Integer, {'explicit': 200, 'optional': True}),
@@ -2040,35 +2040,35 @@ class AuthorizationList(Sequence):
         ('rollback_resistance', Null, {'explicit': 303, 'optional': True}),
         ('early_boot_only', Null, {'explicit': 305, 'optional': True}),
         ('active_date_time', UnixTimestamp, {'explicit': 400, 'optional': True}),
-        ('origination_expire_date_time', UnixTimestamp, {'explicit': 401,'optional': True}),
-        ('usage_expire_date_time', UnixTimestamp, {'explicit': 402,'optional': True}),
+        ('origination_expire_date_time', UnixTimestamp, {'explicit': 401, 'optional': True}),
+        ('usage_expire_date_time', UnixTimestamp, {'explicit': 402, 'optional': True}),
         ('usage_count_limit', Integer, {'explicit': 405, 'optional': True}),
         ('no_auth_required', Null, {'explicit': 503, 'optional': True}),
-        ('user_auth_type', UserAuthenticationType, {'explicit': 504,'optional': True}),
-        ('auth_timeout', Integer, {'explicit': 505,'optional': True}),
+        ('user_auth_type', UserAuthenticationType, {'explicit': 504, 'optional': True}),
+        ('auth_timeout', Integer, {'explicit': 505, 'optional': True}),
         ('allow_while_on_body', Null, {'explicit': 506, 'optional': True}),
         ('trusted_user_presence_required', Null, {'explicit': 507, 'optional': True}),
         ('trusted_confirmation_required', Null, {'explicit': 508, 'optional': True}),
         ('unlocked_device_required', Null, {'explicit': 509, 'optional': True}),
         ('all_applications', Null, {'explicit': 600, 'optional': True}),
-        ('application_id', OctetString,{'explicit': 601,'optional': True}),
-        ('creation_date_time', UnixTimestamp, {'explicit': 701,'optional': True}),
-        ('origin', Origin, {'explicit': 702,'optional': True}),
+        ('application_id', OctetString,{'explicit': 601, 'optional': True}),
+        ('creation_date_time', UnixTimestamp, {'explicit': 701, 'optional': True}),
+        ('origin', Origin, {'explicit': 702, 'optional': True}),
         ('rollback_resistant', Null, {'explicit': 703, 'optional': True}),
-        ('root_of_trust', RootOfTrust, {'explicit': 704,'optional': True}),
-        ('os_version', Integer, {'explicit': 705,'optional': True}),
-        ('os_patch_level', Integer, {'explicit': 706,'optional': True}),
-        ('attestation_application_id', AttestationApplicationIdWrapper, {'explicit': 709,'optional':True}),
-        ('attestation_id_brand', OctetString, {'explicit': 710,'optional': True}),
-        ('attestation_id_device', OctetString, {'explicit': 711,'optional': True}),
+        ('root_of_trust', RootOfTrust, {'explicit': 704, 'optional': True}),
+        ('os_version', Integer, {'explicit': 705, 'optional': True}),
+        ('os_patch_level', Integer, {'explicit': 706, 'optional': True}),
+        ('attestation_application_id', AttestationApplicationIdWrapper, {'explicit': 709, 'optional':True}),
+        ('attestation_id_brand', OctetString, {'explicit': 710, 'optional': True}),
+        ('attestation_id_device', OctetString, {'explicit': 711, 'optional': True}),
         ('attestation_id_product', OctetString, {'explicit': 712, 'optional': True}),
-        ('attestation_id_serial', OctetString, {'explicit': 713,'optional': True}),
-        ('attestation_id_imei', OctetString, {'explicit': 714,'optional': True}),
-        ('attestation_id_meid', OctetString, {'explicit': 715,'optional': True}),
-        ('attestation_id_manufacturer', OctetString, {'explicit': 716,'optional': True}),
-        ('attestation_id_model', OctetString, {'explicit': 717,'optional': True}),
-        ('vendor_patch_level', Integer, {'explicit': 718,'optional': True}),
-        ('boot_patch_level', Integer, {'explicit': 719,'optional': True}),
+        ('attestation_id_serial', OctetString, {'explicit': 713, 'optional': True}),
+        ('attestation_id_imei', OctetString, {'explicit': 714, 'optional': True}),
+        ('attestation_id_meid', OctetString, {'explicit': 715, 'optional': True}),
+        ('attestation_id_manufacturer', OctetString, {'explicit': 716, 'optional': True}),
+        ('attestation_id_model', OctetString, {'explicit': 717, 'optional': True}),
+        ('vendor_patch_level', Integer, {'explicit': 718, 'optional': True}),
+        ('boot_patch_level', Integer, {'explicit': 719, 'optional': True}),
         ('device_unique_attestation', Null, {'explicit': 720, 'optional': True}),
     ]
 
@@ -3310,4 +3310,3 @@ class CertificateAux(Sequence):
 
 class TrustedCertificate(Concat):
     _child_specs = [Certificate, CertificateAux]
-

--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -49,7 +49,6 @@ from .core import (
     OctetBitString,
     OctetString,
     ParsableOctetString,
-    Primitive,
     PrintableString,
     Sequence,
     SequenceOf,
@@ -2029,7 +2028,7 @@ class RootOfTrust(Sequence):
 
 class AuthorizationList(Sequence):
     _fields = [
-        ('purpose',SetOfPurposes,{'explicit': 1, 'optional': True}),
+        ('purpose', SetOfPurposes, {'explicit': 1, 'optional': True}),
         ('algorithm', AlgorithmType, {'explicit': 2, 'optional': True}),
         ('key_size', Integer, {'explicit': 3, 'optional': True}),
         ('digest', SetOfDigests, {'explicit': 5, 'optional': True}),
@@ -2051,14 +2050,14 @@ class AuthorizationList(Sequence):
         ('trusted_confirmation_required', Null, {'explicit': 508, 'optional': True}),
         ('unlocked_device_required', Null, {'explicit': 509, 'optional': True}),
         ('all_applications', Null, {'explicit': 600, 'optional': True}),
-        ('application_id', OctetString,{'explicit': 601, 'optional': True}),
+        ('application_id', OctetString, {'explicit': 601, 'optional': True}),
         ('creation_date_time', UnixTimestamp, {'explicit': 701, 'optional': True}),
         ('origin', Origin, {'explicit': 702, 'optional': True}),
         ('rollback_resistant', Null, {'explicit': 703, 'optional': True}),
         ('root_of_trust', RootOfTrust, {'explicit': 704, 'optional': True}),
         ('os_version', Integer, {'explicit': 705, 'optional': True}),
         ('os_patch_level', Integer, {'explicit': 706, 'optional': True}),
-        ('attestation_application_id', AttestationApplicationIdWrapper, {'explicit': 709, 'optional':True}),
+        ('attestation_application_id', AttestationApplicationIdWrapper, {'explicit': 709, 'optional': True}),
         ('attestation_id_brand', OctetString, {'explicit': 710, 'optional': True}),
         ('attestation_id_device', OctetString, {'explicit': 711, 'optional': True}),
         ('attestation_id_product', OctetString, {'explicit': 712, 'optional': True}),

--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -372,7 +372,7 @@ class IPAddress(OctetString):
         self._native = original_value
         self.contents = inet_pton(family, value) + cidr_bytes
         self._bytes = self.contents
-        self._header = None
+        self._header = 'None'
         if self._trailer != b'':
             self._trailer = b''
 
@@ -1961,6 +1961,31 @@ class SetOfPackageInfos(SetOf):
     _child_spec = PackageInfo
 
 
+# if set it is True
+class StatusSet(Null):
+    def set(self, value):
+        """
+        Sets the value of the object
+
+        :param value:
+            None or 'True'
+        """
+
+        if value is not None and value != 'True' and not isinstance(value, Null):
+            raise ValueError(unwrap(
+                '''
+                value must be one of None, "True", not %s
+                ''',
+                repr(value)
+            ))
+
+        self.contents = b''
+
+    @property
+    def native(self):
+        return 'True'
+
+
 class AttestationApplicationId(Sequence):
     _fields = [
         ('package_infos', SetOfPackageInfos),
@@ -2036,24 +2061,24 @@ class AuthorizationList(Sequence):
         ('ec_curve', EllipticCurveType, {'explicit': 10, 'optional': True}),
         ('rsa_public_exponent', Integer, {'explicit': 200, 'optional': True}),
         ('mfg_digest', SetOfInteger, {'explicit': 203, 'optional': True}),
-        ('rollback_resistance', Null, {'explicit': 303, 'optional': True}),
-        ('early_boot_only', Null, {'explicit': 305, 'optional': True}),
+        ('rollback_resistance', StatusSet, {'explicit': 303, 'optional': True}),
+        ('early_boot_only', StatusSet, {'explicit': 305, 'optional': True}),
         ('active_date_time', UnixTimestamp, {'explicit': 400, 'optional': True}),
         ('origination_expire_date_time', UnixTimestamp, {'explicit': 401, 'optional': True}),
         ('usage_expire_date_time', UnixTimestamp, {'explicit': 402, 'optional': True}),
         ('usage_count_limit', Integer, {'explicit': 405, 'optional': True}),
-        ('no_auth_required', Null, {'explicit': 503, 'optional': True}),
+        ('no_auth_required', StatusSet, {'explicit': 503, 'optional': True}),
         ('user_auth_type', UserAuthenticationType, {'explicit': 504, 'optional': True}),
         ('auth_timeout', Integer, {'explicit': 505, 'optional': True}),
-        ('allow_while_on_body', Null, {'explicit': 506, 'optional': True}),
-        ('trusted_user_presence_required', Null, {'explicit': 507, 'optional': True}),
-        ('trusted_confirmation_required', Null, {'explicit': 508, 'optional': True}),
-        ('unlocked_device_required', Null, {'explicit': 509, 'optional': True}),
-        ('all_applications', Null, {'explicit': 600, 'optional': True}),
+        ('allow_while_on_body', StatusSet, {'explicit': 506, 'optional': True}),
+        ('trusted_user_presence_required', StatusSet, {'explicit': 507, 'optional': True, }),
+        ('trusted_confirmation_required', StatusSet, {'explicit': 508, 'optional': True}),
+        ('unlocked_device_required', StatusSet, {'explicit': 509, 'optional': True}),
+        ('all_applications', StatusSet, {'explicit': 600, 'optional': True}),
         ('application_id', OctetString, {'explicit': 601, 'optional': True}),
         ('creation_date_time', UnixTimestamp, {'explicit': 701, 'optional': True}),
         ('origin', Origin, {'explicit': 702, 'optional': True}),
-        ('rollback_resistant', Null, {'explicit': 703, 'optional': True}),
+        ('rollback_resistant', StatusSet, {'explicit': 703, 'optional': True}),
         ('root_of_trust', RootOfTrust, {'explicit': 704, 'optional': True}),
         ('os_version', Integer, {'explicit': 705, 'optional': True}),
         ('os_patch_level', Integer, {'explicit': 706, 'optional': True}),
@@ -2068,7 +2093,7 @@ class AuthorizationList(Sequence):
         ('attestation_id_model', OctetString, {'explicit': 717, 'optional': True}),
         ('vendor_patch_level', Integer, {'explicit': 718, 'optional': True}),
         ('boot_patch_level', Integer, {'explicit': 719, 'optional': True}),
-        ('device_unique_attestation', Null, {'explicit': 720, 'optional': True}),
+        ('device_unique_attestation', StatusSet, {'explicit': 720, 'optional': True}),
     ]
 
 


### PR DESCRIPTION
I would like to extend x509.py to support the X509v3 Extension «AttestationExtension» (OID «1.3.6.1.4.1.11129.2.1.17»).

The definition is outlined under https://developer.android.com/training/articles/security-key-attestation.html.

Most added classes are straight forward. However, there are 2 classes which are hacky and need to be improved (they might be even at the wrong place): 
•	`class AttestationApplicationIdWrapper(ParsableOctetString)`
•	`class UnixTimestamp(Integer)`

Please advise. 

