### PR TITLE
Fix error "image ubuntu-2004:202101-01 is not a valid resource class" on circleci.com

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   python2.7:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:2024.11.1
     resource_class: arm.medium
     steps:
       - checkout
@@ -10,7 +10,7 @@ jobs:
       - run: python run.py ci-driver
   python3.9:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:2024.11.1
     resource_class: arm.medium
     steps:
       - checkout


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e825e787-bf9a-4db1-a12e-7312078bbdfd)
