### PR TITLE
Correct handling of Void response_bytes in OCSP

### DIFF
--- a/asn1crypto/ocsp.py
+++ b/asn1crypto/ocsp.py
@@ -628,13 +628,14 @@ class OCSPResponse(Sequence):
 
         self._critical_extensions = set()
 
-        for extension in self['response_bytes']['response'].parsed['tbs_response_data']['response_extensions']:
-            name = extension['extn_id'].native
-            attribute_name = '_%s_value' % name
-            if hasattr(self, attribute_name):
-                setattr(self, attribute_name, extension['extn_value'].parsed)
-            if extension['critical'].native:
-                self._critical_extensions.add(name)
+        if self['response_bytes']:
+            for extension in self['response_bytes']['response'].parsed['tbs_response_data']['response_extensions']:
+                name = extension['extn_id'].native
+                attribute_name = '_%s_value' % name
+                if hasattr(self, attribute_name):
+                    setattr(self, attribute_name, extension['extn_value'].parsed)
+                if extension['critical'].native:
+                    self._critical_extensions.add(name)
 
         self._processed_extensions = True
 
@@ -689,7 +690,7 @@ class OCSPResponse(Sequence):
             None or an asn1crypto.ocsp.BasicOCSPResponse object
         """
 
-        return self['response_bytes']['response'].parsed
+        return self['response_bytes']['response'].parsed if self['response_bytes'] else None
 
     @property
     def response_data(self):
@@ -700,4 +701,4 @@ class OCSPResponse(Sequence):
             None or an asn1crypto.ocsp.ResponseData object
         """
 
-        return self['response_bytes']['response'].parsed['tbs_response_data']
+        return self['response_bytes']['response'].parsed['tbs_response_data'] if self['response_bytes'] else None


### PR DESCRIPTION
`response_bytes` is optional, thus `Void` when omitted, which happens with some statuses (like 'unauthorized'). Make all properties return correct values in this case: `None` for everything except `critical_extensions` which is the empty set.
I wrote it with a guard that causes the indent to increase - could be rewritten as
```
if not self['response_bytes']
    self._processed_extensions = True
    return
```
if early return and repeating `self._processed_extensions = True` is deemed less bothersome than the increased indent.

The simple ternary operator fix for `basic_ocsp_response` and `response_data` may not be enough for every case as there are several more layers of unwrapping that need to be error-free, but looking at #246 and #262 this should fix the `TypeError` although user code will (still) have to check for `None` but the docstrings always indicated that possibility.

The test code I didn't write might include this - it's what a real 'unauthorized' response looks like (I got it from Let's Encrypt when querying an expired cert)
```
resp = ocsp.OCSPResponse.load(b'0\x03\n\x01\x06') # only 5 bytes
```
Yes, that short: a sequence with an enumerated '6' value, and the `response_bytes` is completely omitted.