### PR TITLE
fix(core): add recursion depth limit to prevent unbounded recursion in .native

### DIFF
--- a/asn1crypto/core.py
+++ b/asn1crypto/core.py
@@ -3877,7 +3877,9 @@ class Sequence(Asn1Value):
 
         return new_value
 
-    def _parse_children(self, recurse=False):
+    _MAX_RECURSION_DEPTH = 500
+
+    def _parse_children(self, recurse=False, _depth=0):
         """
         Parses the contents and generates Asn1Value objects based on the
         definitions from _fields.
@@ -3886,9 +3888,18 @@ class Sequence(Asn1Value):
             If child objects that are Sequence or SequenceOf objects should
             be recursively parsed
 
+        :param _depth:
+            Internal recursion depth counter
+
         :raises:
             ValueError - when an error occurs parsing child objects
         """
+
+        if _depth > self._MAX_RECURSION_DEPTH:
+            raise ValueError('Maximum recursion depth (%d) exceeded while '
+                             'parsing %s - input may be malformed or contain '
+                             'excessively nested structures' %
+                             (self._MAX_RECURSION_DEPTH, type_name(self)))
 
         cls = self.__class__
         if self._contents is None:
@@ -3985,7 +3996,7 @@ class Sequence(Asn1Value):
                 if recurse:
                     child = _build(*child)
                     if isinstance(child, (Sequence, SequenceOf)):
-                        child._parse_children(recurse=True)
+                        child._parse_children(recurse=True, _depth=_depth+1)
 
                 self.children.append(child)
                 field += 1
@@ -4518,7 +4529,7 @@ class SequenceOf(Asn1Value):
                 if recurse:
                     child = _build(*child)
                     if isinstance(child, (Sequence, SequenceOf)):
-                        child._parse_children(recurse=True)
+                        child._parse_children(recurse=True, _depth=_depth+1)
                 self.children.append(child)
         except (ValueError, TypeError) as e:
             self.children = None
@@ -4722,7 +4733,7 @@ class Set(Sequence):
                 if recurse:
                     child = _build(*child)
                     if isinstance(child, (Sequence, SequenceOf)):
-                        child._parse_children(recurse=True)
+                        child._parse_children(recurse=True, _depth=_depth+1)
 
                 child_map[field] = child
                 seen_field += 1


### PR DESCRIPTION
## Problem

Calling `.native` on a deeply nested ASN.1 `Sequence`/`Set`/`SequenceOf` structure causes an unbounded `RecursionError`. The issue is in `_parse_children(recurse=True)`, which recursively calls itself on child Sequence/SequenceOf objects without any depth limit.

**PoC (from #300):**
```python
from asn1crypto.parser import emit
from asn1crypto.core import load

payload = emit(0, 0, 5, b"")
for __ in range(5000):
    payload = emit(0, 1, 16, payload)

parsed = load(payload)
native = parsed.native  # RecursionError
```

## Fix

- Add `_MAX_RECURSION_DEPTH = 500` class constant to `Sequence`
- Add `_depth` parameter to `_parse_children()` (default 0), incremented on each recursive call
- When depth exceeds the limit, raise `ValueError` with a clear diagnostic message instead of hitting Python's `RecursionError`
- Applied to all three recursive call sites: `Sequence`, `SequenceOf`, and `Set._parse_children`

The limit of 500 is generous enough for any real-world ASN.1 structure (X.509 certs, CMS, OCSP etc. typically nest < 10 levels deep) while preventing stack exhaustion from crafted inputs.

## Impact

- Callers already catching `Exception` (as recommended for untrusted data) are unaffected — `ValueError` is a subclass of `Exception`
- The error message is more informative than a raw `RecursionError`
- Normal usage is completely unchanged

Fixes #300