### PR TITLE
fix(core): correct BER indefinite length detection in dump() methods

### DIFF
--- a/asn1crypto/core.py
+++ b/asn1crypto/core.py
@@ -644,7 +644,7 @@ class Asn1Value(object):
         contents = self.contents
 
         # If the length is indefinite, force the re-encoding
-        if self._header is not None and self._header[-1:] == b'\x80':
+        if self._header is not None and len(self._header) >= 2 and self._header[1] == 0x80:
             force = True
 
         if self._header is None or force:
@@ -1350,7 +1350,7 @@ class Choice(Asn1Value):
         """
 
         # If the length is indefinite, force the re-encoding
-        if self._header is not None and self._header[-1:] == b'\x80':
+        if self._header is not None and len(self._header) >= 2 and self._header[1] == 0x80:
             force = True
 
         self._contents = self.chosen.dump(force=force)
@@ -1727,7 +1727,7 @@ class Primitive(Asn1Value):
         """
 
         # If the length is indefinite, force the re-encoding
-        if self._header is not None and self._header[-1:] == b'\x80':
+        if self._header is not None and len(self._header) >= 2 and self._header[1] == 0x80:
             force = True
 
         if force:
@@ -4136,7 +4136,7 @@ class Sequence(Asn1Value):
         """
 
         # If the length is indefinite, force the re-encoding
-        if self._header is not None and self._header[-1:] == b'\x80':
+        if self._header is not None and len(self._header) >= 2 and self._header[1] == 0x80:
             force = True
 
         # We can't force encoding if we don't have a spec
@@ -4608,7 +4608,7 @@ class SequenceOf(Asn1Value):
         """
 
         # If the length is indefinite, force the re-encoding
-        if self._header is not None and self._header[-1:] == b'\x80':
+        if self._header is not None and len(self._header) >= 2 and self._header[1] == 0x80:
             force = True
 
         if force:


### PR DESCRIPTION
## Problem

`_header[-1:] == b\"\\x80\"` incorrectly matches long-form length encodings where the length value ends with `0x80`. For example, a length of 128 bytes is encoded as `0x81 0x80` (long form: 1 length byte follows, value = 128). The old check matches this as "indefinite length" because the last byte happens to be `0x80`, but it is actually a valid definite-length encoding.

This causes valid BER-encoded data with long-form lengths to be forcefully re-encoded, which can corrupt structures that were intentionally encoded in BER format.

## Root Cause

In ASN.1 BER encoding:
- Length byte == `0x80` → **indefinite length** (no content bytes follow until end-of-contents)
- Length byte >= `0x81` → **long form definite length** (lower 7 bits = number of subsequent length bytes)

The old code only checked the last byte of the header, conflating these two cases.

## Fix

Change all 5 occurrences from:
```python
self._header[-1:] == bx80
```
to:
```python
len(self._header) >= 2 and self._header[1] == 0x80
```

This checks that the **length byte** (second byte of header for standard tags) is exactly `0x80`, correctly identifying indefinite length while excluding long-form encodings where the length value coincidentally ends in `0x80`.

## Testing

- All 807 existing tests pass
- Verified: indefinite length (`\\x30\\x80`) still detected ✓
- Verified: long-form length 128 (`\\x02\\x81\\x80`) no longer falsely matched ✓

Fixes #249