### PR TITLE
fix(tsp): mark time_stamp_token as optional in TimeStampResp

### DIFF
--- a/asn1crypto/tsp.py
+++ b/asn1crypto/tsp.py
@@ -156,7 +156,7 @@ class PKIStatusInfo(Sequence):
 class TimeStampResp(Sequence):
     _fields = [
         ('status', PKIStatusInfo),
-        ('time_stamp_token', ContentInfo),
+        ('time_stamp_token', ContentInfo, {'optional': True}),
     ]
 
 


### PR DESCRIPTION
## Summary

Per RFC 3161 section 2.4.2, the `timeStampToken` field in `TimeStampResp` is OPTIONAL:

```asn
TimeStampResp ::= SEQUENCE {
   status                  PKIStatusInfo,
   timeStampToken          ContentInfo OPTIONAL
}
```

When the TSA returns a rejection or failure status (e.g., `unacceptedPolicy`), the `timeStampToken` field is absent. Currently, parsing such a response raises:

```
ValueError: Field "time_stamp_token" is missing from structure
   while parsing asn1crypto.tsp.TimeStampResp
```

## Fix

Mark `time_stamp_token` as optional in `TimeStampResp._fields`. One-line change.

Fixes #286