### PR TITLE
fix(x509): add _oid_pair/_oid_specs to AnotherName for DEFINED BY support

### DIFF
--- a/asn1crypto/x509.py
+++ b/asn1crypto/x509.py
@@ -1188,6 +1188,9 @@ class AnotherName(Sequence):
         ('value', Any, {'explicit': 0}),
     ]
 
+    _oid_pair = ('type_id', 'value')
+    _oid_specs = {}
+
 
 class CountryName(Choice):
     class_ = 1


### PR DESCRIPTION
## Summary

Fixes #231 — **AnotherName not encoded correctly**

Per RFC 5280 Section 4.2.1.6, the `AnotherName.value` field is a DEFINED BY type that should be resolved based on the `type_id` OID. The class definition was missing `_oid_pair` and `_oid_specs`, so the library had no way to know about this OID-to-type relationship during encoding or decoding.

## Details

- Adds `_oid_pair = ("type_id", "value")` and `_oid_specs = {}` to `AnotherName`
- This enables the existing DEFINED BY mechanism in `core.py` (same pattern used by `ContentInfo` in `cms.py`)
- With `_oid_specs` left empty as a dict, users can register their own OID mappings (e.g. `AnotherName._oid_specs["1.3.6.1.4.1.311.20.2.3"] = UTF8String`) for proper round-trip encoding/decoding
- All 807 existing tests pass

## References

- Suggested by @MatthiasValvekens in [#231 (comment)](https://github.com/wbond/asn1crypto/issues/231#issuecomment-1150218407)
- Confirmed by @wbond in [#231 (comment)](https://github.com/wbond/asn1crypto/issues/231#issuecomment-1162799952)